### PR TITLE
Problems with italian translation

### DIFF
--- a/grid.user.js
+++ b/grid.user.js
@@ -38,8 +38,8 @@
       includeOwnVideo: 'Vous inclure dans la grille',
     },
     it: {
-      showOnlyVideo: 'Mostra solo partecipanti con video',
-      highlightSpeaker: 'Illumina chi ha la paola',
+      showOnlyVideo: 'Mostra solo i partecipanti con la fotocamera attiva',
+      highlightSpeaker: 'Illumina chi sta parlando',
       includeOwnVideo: 'Includi te stesso nella griglia',
     },
     nl: {


### PR DESCRIPTION
I propose changing "illumina la parola" with "illumina chi sta parlando" (that means "light up who's talking") and "mostra solo partecipanti con video" with "mostra solo i partecipanti con la fotocamera attiva" (that means "show only people with switched on camera")