### PR TITLE
Add target="_blank" to links in popup container

### DIFF
--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -40,7 +40,7 @@
 
     <div class="spacer"></div>
 
-    <a id="source-code" href="https://github.com/Fugiman/google-meet-grid-view">
+    <a id="source-code" href="https://github.com/Fugiman/google-meet-grid-view" target="_blank">
       Source Code available on Github
     </div>
 


### PR DESCRIPTION
Can't follow links within the popup container due to Chrome permissions. Have to set a target="_blank" to make them actually open a page (or use the tab.open thing, but that requires extra permissions)